### PR TITLE
Use random hierarchy when generating batches.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean-build: ## remove build artifacts
 	rm -fr dist/
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	find . -name '*.egg' -exec rm -fr {} +
 
 clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +

--- a/iam_profile_faker/factory.py
+++ b/iam_profile_faker/factory.py
@@ -30,7 +30,7 @@ def decorate_metadata_signature(fun):
 
 
 def create_random_hierarchy_iter():
-    """Generate hierarchy iterator with a random pattern pattern"""
+    """Generate hierarchy iterator with a random pattern"""
     def gen():
         for i in itertools.count():
             yield (i + 1, random.randint(0, i))


### PR DESCRIPTION
This assures that all *manager_id's* exist as an *employee_id*.
Except for *manager_id = 0* which is used now to denote that a person
reports to nobody.